### PR TITLE
Custom spans for streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["parsing", "text-processing"]
 [dependencies]
 hashbrown = "0.14.0"
 aott_derive = { path = "./derive" }
+num-traits = "0.2.16"
 
 [features]
 std = []

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,7 +7,7 @@ use core::{
 use crate::{
         error::{Error, Located, Span},
         parser::{Parser, ParserExtras, SimpleExtras},
-        stream::Stream,
+        stream::{Spanned, SpannedStream, Stream},
         text::Char,
 };
 
@@ -16,6 +16,8 @@ use self::private::Sealed;
 mod private {
         pub trait Sealed {}
 }
+
+impl<T, S: Spanned<T>, I: Iterator<Item = S>> Sealed for SpannedStream<T, S, I> {}
 
 #[allow(clippy::module_name_repetitions)]
 pub trait InputType: Sealed {


### PR DESCRIPTION
Fixes #6

This PR adds the ability to specify custom spans for streams, for example for use with Logos's `SpannedIter`.